### PR TITLE
Enable selecting text in PDF when embedding fonts

### DIFF
--- a/src/qt/qtbase/src/gui/painting/qpdf.cpp
+++ b/src/qt/qtbase/src/gui/painting/qpdf.cpp
@@ -2500,14 +2500,14 @@ void QPdfEnginePrivate::drawTextItem(const QPointF &p, const QTextItemInt &ti)
     QFontEngine::FaceId face_id = fe->faceId();
     bool noEmbed = false;
     if (!embedFonts
-        || face_id.filename.isEmpty()
+        /*|| face_id.filename.isEmpty()*/
         || fe->fsType & 0x200 /* bitmap embedding only */
         || fe->fsType == 2 /* no embedding allowed */) {
         *currentPage << "Q\n";
         q->QPaintEngine::drawTextItem(p, ti);
         *currentPage << "q\n";
-        if (face_id.filename.isEmpty())
-            return;
+        /*if (face_id.filename.isEmpty())
+            return;*/
         noEmbed = true;
     }
 


### PR DESCRIPTION
Workaround to not check for filename in qtbase provided by astefanutti: https://github.com/ariya/phantomjs/issues/13997